### PR TITLE
POC script for syncing Python pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Sample comment
 
     - [pytest](https://docs.pytest.org/en/latest/) and [coverage.py](https://coverage.readthedocs.io/en/latest/) to run the tests
     - [pre-commit](https://pre-commit.com/) to run formatters and linters on every commit
-        - [mypy](https://mypy.readthedocs.io/en/latest/) to check types
-        - [black](https://black.readthedocs.io/en/stable/) to format the code
-        - [flake8](http://flake8.pycqa.org/en/latest/) to identify coding errors and check code style
-        - [pydocstyle](http://www.pydocstyle.org/en/latest/) to check docstring style
+    - [mypy](https://mypy.readthedocs.io/en/latest/) to check types
+    - [black](https://black.readthedocs.io/en/stable/) to format the code
+    - [flake8](http://flake8.pycqa.org/en/latest/) to identify coding errors and check code style
+    - [pydocstyle](http://www.pydocstyle.org/en/latest/) to check docstring style

--- a/scripts/sync_pre_commit.py
+++ b/scripts/sync_pre_commit.py
@@ -1,0 +1,57 @@
+# type: ignore
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+
+from pre_commit.clientlib import load_config
+from pre_commit.repository import all_hooks
+from pre_commit.store import Store
+
+ROOT_PATH = pathlib.Path(__file__).parents[1]
+
+
+def main():
+    """Install pre-commit hooks in local virtual environment."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="increase output verbosity",
+        dest="quiet",
+        action="store_false",
+    )
+    args = parser.parse_args()
+
+    os.environ["PIP_REQUIRE_VIRTUALENV"] = "true"
+
+    config_file = ROOT_PATH / ".pre-commit-config.yaml"
+    hooks = all_hooks(load_config(config_file), Store())
+
+    for hook in hooks:
+        # TODO: Avoid duplicate installs from same repo
+        # e.g. pre-commit/pre-commit-hooks
+        if hook.language == "python":
+            install_python_hook(hook, args.quiet)
+        else:
+            print(f"Skipping {hook.id}: unsupported language '{hook.language}'")
+
+
+def install_python_hook(hook, quiet=True):
+    """Install a Python pre-commit hook."""
+    print(f"Installing {hook.entry}")
+
+    # Upgrading packages to use most recent source (instead of version)
+    command = [
+        "pip",
+        "install",
+        "--upgrade",
+        hook.prefix.path(),
+    ] + hook.additional_dependencies
+
+    subprocess.run(command, check=True, capture_output=quiet)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,4 @@ deps =
     {[testenv:check]deps}
 commands =
     pre-commit install --install-hooks
+    python scripts/sync_pre_commit.py


### PR DESCRIPTION
An attempt to single-source the versions of linters and formatters configured for pre-commit, e.g. to run them from the command line, or use in my editor (VS Code).

See:

https://github.com/pre-commit/pre-commit/issues/945
https://github.com/pre-commit/pre-commit/issues/730